### PR TITLE
Update section on dnsmasq + sqlpro 

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ User: 		wp
 Pass: 		wp
 Database: 	(empty)
 Port: 		3306
-SSH Host: 	vvv.dev
+SSH Host: 	vvv.test
 SSH User: 	vagrant
 SSH Pass: 	vagrant
 SSH Port: 	(none)

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Basically, when you are using SSH or SSH tunnels, you need to "grant access" to 
 ### Configure `dnsmasq`
 This assumes you use the standard VVV with VirtualBox and the default IP.
 Install: dnsmasq was installed above, if you skipped it `brew install dnsmasq`
-Setup (https://echo.co/blog/never-touch-your-local-etchosts-file-os-x-again):
+Setup (https://alanthing.com/blog/2012/04/24/never-touch-your-local-etchosts-file-os-x-again/):
 
 ```bash
 mkdir -pv $(brew --prefix)/etc/


### PR DESCRIPTION
This PR:

- Replaces the link https://echo.co/blog/never-touch-your-local-etchosts-file-os-x-again with https://alanthing.com/blog/2012/04/24/never-touch-your-local-etchosts-file-os-x-again/, the original link now 404's but Alan blog was able to have a copy of it

- Change `vvv.dev` to `vvv.test` since `Quick setup of VVV` uses `vvv.test` as ssh host
reference: https://varyingvagrantvagrants.org/docs/en-US/installation/